### PR TITLE
Fit map zoom and center to given bounds

### DIFF
--- a/leafletwidget/leaflet.py
+++ b/leafletwidget/leaflet.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import json
+import math
 
 from IPython.utils.traitlets import (
     Float, Unicode, Int, Tuple, List, Instance, Bool, Dict
@@ -407,4 +408,31 @@ class Map(widgets.DOMWidget, InteractMixin):
 
     def _handle_leaflet_event(self, _, content):
         pass
+
+    def fitBounds(self, southwest, northeast):
+        """Set the map's center and zoom such that the map's extent
+        fits the given bounds.
+
+        The `southwest` arg is a pair of (south, west) values and
+        the `northeast` arg is a pair of (north, east) values. The
+        statement
+
+            map.fitBounds(*map.bounds)
+
+        would therefore be a no-op. NB: until a map has been displayed,
+        its extent is undetermined.
+        """
+        south, west = southwest
+        north, east = northeast
+        w = east - west
+        h = north - south
+        _ = self.bounds
+        (cur_south, cur_west), (cur_north, cur_east) = self.bounds
+        cur_w = cur_east - cur_west
+        cur_h = cur_north - cur_south
+        delta_zoom = math.floor(
+            min(math.log(cur_w/w, 2), math.log(cur_h/h, 2)))
+
+        self.zoom += int(delta_zoom)
+        self.center = [(north + south)/2, (east + west)/2]
 

--- a/leafletwidget/leaflet.py
+++ b/leafletwidget/leaflet.py
@@ -426,13 +426,11 @@ class Map(widgets.DOMWidget, InteractMixin):
         north, east = northeast
         w = east - west
         h = north - south
-        _ = self.bounds
         (cur_south, cur_west), (cur_north, cur_east) = self.bounds
         cur_w = cur_east - cur_west
         cur_h = cur_north - cur_south
         delta_zoom = math.floor(
             min(math.log(cur_w/w, 2), math.log(cur_h/h, 2)))
-
         self.zoom += int(delta_zoom)
         self.center = [(north + south)/2, (east + west)/2]
 


### PR DESCRIPTION
Screenshot of code in action:

![sheely](https://cloud.githubusercontent.com/assets/33697/2937733/dc1957a6-d8cb-11e3-8bf4-cc22cc652d82.png)

I'm using my Shapely library in this example to perform a "sloppy" 100 meter buffer on a GeoJSON polygon and then fit the map to the buffered extents.

I notice that until the map is rendered via `display(m)` the model's `_south`, `_west`, `_north`, and `_east` have only the default values. I'd like to be able to fit to bounds without having to display first, but I'm not sure how to do that yet.
