### PR TITLE
Dynamic setup of webpack public path based on base Url

### DIFF
--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -1,6 +1,3 @@
-// Setup notebook base URL
-__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-leaflet/';
-
 // Load css
 require('leaflet/dist/leaflet.css');
 require('leaflet-draw/dist/leaflet.draw.css');

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -41,8 +41,7 @@ module.exports = [
         output: {
             filename: 'index.js',
             path: '../ipyleaflet/static',
-            libraryTarget: 'amd',
-            publicPath: '/nbextensions/jupyter-leaflet/'
+            libraryTarget: 'amd'
         },
         devtool: 'source-map',
         module: {
@@ -51,7 +50,7 @@ module.exports = [
         externals: ['jupyter-js-widgets']
     },
     {// embeddable jupyter-leaflet bundle
-        entry: './src/index.js',
+        entry: './src/embed.js',
         output: {
             filename: 'index.js',
             path: './dist/',


### PR DESCRIPTION
This should make the marker static URL work when the baseURL is not `/`.