### PR TITLE
use https everywhere

### DIFF
--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -109,11 +109,11 @@ class TileLayer(RasterLayer):
     _model_name = Unicode('LeafletTileLayerModel').tag(sync=True)
 
     bottom = Bool(True).tag(sync=True)
-    url = Unicode('http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png').tag(sync=True)
+    url = Unicode('https://otile1-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png').tag(sync=True)
     min_zoom = Int(0).tag(sync=True, o=True)
     max_zoom = Int(18).tag(sync=True, o=True)
     tile_size = Int(256).tag(sync=True, o=True)
-    attribution = Unicode('Map data (c) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors').tag(sync=True, o=True)
+    attribution = Unicode('Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors').tag(sync=True, o=True)
     opacity = Float(1.0).tag(sync=True, o=True)
     detect_retina = Bool(False).tag(sync=True, o=True)
 

--- a/js/README.md
+++ b/js/README.md
@@ -10,7 +10,7 @@ Package Install
 ---------------
 
 **Prerequisites**
-- [node](http://nodejs.org/)
+- [node](https://nodejs.org/)
 
 ```bash
 npm install --save jupyter-leaflet

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -520,11 +520,11 @@ var LeafletTileLayerModel = LeafletRasterLayerModel.extend({
         _model_name : 'LeafletTileLayerModel',
 
         bottom : true,
-        url : 'http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png',
+        url : 'https://otile1-s.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png',
         min_zoom : 0,
         max_zoom : 18,
         tile_size : 256,
-        attribution : 'Map data (c) <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+        attribution : 'Map data (c) <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
         opacity : 1.0,
         detect_retina : false
     })


### PR DESCRIPTION
needed to avoid insecure content warnings when loaded on https pages (e.g. jupyter.org)