### PR TITLE
Add leaflet side-by-side support

### DIFF
--- a/examples/CustomTMS.ipynb
+++ b/examples/CustomTMS.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "\n",
+    "from ipyleaflet import (\n",
+    "    Map,\n",
+    "    Marker,\n",
+    "    TileLayer, ImageOverlay,\n",
+    "    Polyline, Polygon, Rectangle, Circle, CircleMarker,\n",
+    "    GeoJSON,\n",
+    "    DrawControl\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom TMS Server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "center = [39.9610845, -75.1540457]\n",
+    "zoom = 14"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(default_tiles=TileLayer(opacity=1.0), center=center, zoom=zoom)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or any other appropriate url\n",
+    "carto_url = (\n",
+    "    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'\n",
+    ")\n",
+    "m.default_tiles.interact(url=carto_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "m.remove_layer(m.default_tiles)\n",
+    "m.add_layer(m.default_tiles)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Side-by-side.ipynb
+++ b/examples/Side-by-side.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Side-by-Side\n",
+    "\n",
+    "This example shows how to use the [Leaflet side-by-side](https://github.com/digidem/leaflet-side-by-side) slider with ipyleaflet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import (\n",
+    "    Map, TileLayer, SideBySideControl\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "center = [34.6252978589571, -77.34580993652344]\n",
+    "zoom = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=center, zoom=zoom)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "left = TileLayer(url='https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png')\n",
+    "right = TileLayer(url='https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png')\n",
+    "control = SideBySideControl(leftLayer=left, rightLayer=right)\n",
+    "m.add_control(control)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -287,6 +287,32 @@ class Control(Widget):
                     self._map.remove_control(self)
 
 
+class SideBySideControl(Control):
+    _view_name = Unicode('LeafletSideBySideControlView').tag(sync=True)
+    _model_name = Unicode('LeafletSideBySideControlModel').tag(sync=True)
+    _draw_callbacks = Instance(CallbackDispatcher, ())
+
+    leftLayer = Instance(TileLayer).tag(sync=True, **widget_serialization)
+    rightLayer = Instance(TileLayer).tag(sync=True, **widget_serialization)
+
+    @default('leftLayer')
+    def _default_leftLayer(self):
+        return TileLayer()
+
+    @default('rightLayer')
+    def _default_rightLayer(self):
+        return TileLayer()
+
+    def __init__(self, **kwargs):
+        super(SideBySideControl, self).__init__(**kwargs)
+        self.on_msg(self._handle_leaflet_event)
+
+    def _handle_leaflet_event(self, _, content, buffers):
+        if content.get('event', '') == 'dividermove':
+            event = content.get('event')
+            self.x = event.x
+
+
 class DrawControl(Control):
     _view_name = Unicode('LeafletDrawControlView').tag(sync=True)
     _model_name = Unicode('LeafletDrawControlModel').tag(sync=True)

--- a/js/package.json
+++ b/js/package.json
@@ -25,6 +25,7 @@
     "jupyter-js-widgets": "3.0.0-alpha.2",
     "leaflet": "^0.7.7",
     "leaflet-draw": "^0.3.0",
+    "leaflet-side-by-side": "^2.0.0",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Overview
------

This PR adds leaflet side-by-side support to `jupyter-leaflet.js` and to leaflet.py.
An example notebook is included to demonstrate functionality.

Testing
------

- Run `Side-by-side.ipynb`
- :tada: