### PR TITLE
Explicitly bundle @jupyter-widgets/base in embed bundle

### DIFF
--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -60,7 +60,6 @@ module.exports = [
         devtool: 'source-map',
         module: {
             loaders: loaders
-        },
-        externals: ['@jupyter-widgets/base']
+        }
     }
 ];


### PR DESCRIPTION
When we create the embed bundle, `@jupyter-widgets/base` is declared as an external dependency, so webpack doesn't bundle it. However, the htmlmanager provided by ipywidgets doesn't provide `@jupyter-widgets/base` to the libraries.

This PR suggests a fix: explicitly bundling `@jupyter-widgets/base` when we create the embed bundle. See [issue #1551 on ipywidgets](https://github.com/jupyter-widgets/ipywidgets/issues/1551) for a discussion of other possible fixes that don't involve changing ipyleaflet directly.

This PR is just a proof of concept -- it definitely shouldn't get merged until issue #1551 on ipywidgets is resolved.