### PR TITLE
Fixup extension version

### DIFF
--- a/ipyleaflet/_version.py
+++ b/ipyleaflet/_version.py
@@ -5,4 +5,4 @@ _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
 
-EXTENSION_VERSION = '0.4.0'
+EXTENSION_VERSION = '~=0.5.0'


### PR DESCRIPTION
This is required to work with `jupyter-leaflet` `0.5.0`.