### PR TITLE
Default to using a LayersControl widget

### DIFF
--- a/examples/BaseMap.ipynb
+++ b/examples/BaseMap.ipynb
@@ -12,7 +12,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from ipyleaflet import *"
@@ -31,7 +33,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Adding a few tile layers\n",
@@ -45,7 +49,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Adding an overlay layer\n",
@@ -67,24 +73,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# Adding the control\n",
-    "m.add_control(LayersControl())"
+    "tile3 = basemap_to_tiles(basemaps.OpenStreetMap.BlackAndWhite)\n",
+    "\n",
+    "m.add_layer(tile3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
@@ -105,7 +109,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -687,11 +687,20 @@ class Map(DOMWidget, InteractMixin):
         self.layers = tuple([l for l in self.layers if l.model_id != layer.model_id])
         layer.visible = False
 
+    @observe('layers')
+    def _update_layers(self, change):
+        # Update layer controls
+        self.controls = [c if not isinstance(c, LayersControl) else LayersControl() for c in self.controls]
+
     def clear_layers(self):
         self.layers = ()
 
     controls = Tuple(trait=Instance(Control)).tag(sync=True, **widget_serialization)
     control_ids = List()
+
+    @default('controls')
+    def _default_controls(self):
+        return (LayersControl(),)
 
     @validate('controls')
     def _validate_controls(self, proposal):


### PR DESCRIPTION
- Create a `LayersControl` by default.
- Observe the list of available layers to update the layers controls upon addition or removal of layers.

cc @DavideDeMarchi
