### PR TITLE
Modernize traitlets API

### DIFF
--- a/examples/Primitives.ipynb
+++ b/examples/Primitives.ipynb
@@ -14,7 +14,8 @@
     "    TileLayer, ImageOverlay,\n",
     "    Polyline, Polygon, Rectangle, Circle, CircleMarker,\n",
     "    GeoJSON,\n",
-    "    DrawControl\n",
+    "    DrawControl,\n",
+    "    basemaps\n",
     ")"
    ]
   },
@@ -41,7 +42,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(default_tiles=TileLayer(opacity=1.0), center=center, zoom=zoom)\n",
+    "m = Map(center=center, zoom=zoom)\n",
     "m"
    ]
   },
@@ -60,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.remove_layer(m.default_tiles)"
+    "m.clear_layers()"
    ]
   },
   {
@@ -69,16 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m.add_layer(m.default_tiles)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m.model_id"
+    "m.add_layer(basemaps.Esri.DeLorme)"
    ]
   },
   {
@@ -113,15 +105,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mark.visible"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "m += mark"
    ]
   },
@@ -132,24 +115,6 @@
    "outputs": [],
    "source": [
     "mark.interact(opacity=(0.0,1.0,0.01))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mark.visible"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "mark.visible = False"
    ]
   },
   {
@@ -175,8 +140,8 @@
     "xscale = 5\n",
     "yscale = 10\n",
     "\n",
-    "x = [m.center[0] + i*xscale*.05 for i in (-1,0,1)]\n",
-    "y = [m.center[1] + i*yscale*.05 for i in (-1,0,1)]\n",
+    "x = [m.center[0] + i * xscale * .05 for i in (-1,0,1)]\n",
+    "y = [m.center[1] + i * yscale * .05 for i in (-1,0,1)]\n",
     "\n",
     "from itertools import product\n",
     "locations = product(x, y)\n",
@@ -197,7 +162,7 @@
    "outputs": [],
    "source": [
     "marker_cluster = MarkerCluster(markers = markers)\n",
-    "m+=marker_cluster"
+    "m += marker_cluster"
    ]
   },
   {
@@ -232,6 +197,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "m.bounds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "m"
    ]
   },
@@ -250,13 +224,6 @@
    "source": [
     "## Polyline"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/js/src/jupyter-leaflet.js
+++ b/js/src/jupyter-leaflet.js
@@ -1000,10 +1000,10 @@ var LeafletMapModel = widgets.DOMWidgetModel.extend({
         // zoom_animation : bool(?),
         zoom_animation_threshold : 4,
         // marker_zoom_animation : bool(?),
-        _south : def_loc[0],
-        _north : def_loc[0],
-        _east : def_loc[1],
-        _west : def_loc[1],
+        south : def_loc[0],
+        north : def_loc[0],
+        east : def_loc[1],
+        west : def_loc[1],
         options : [],
         layers : [],
         controls : []
@@ -1026,10 +1026,10 @@ var LeafletMapModel = widgets.DOMWidgetModel.extend({
                 bnds.west = Math.min(bnds.west, view_bounds.getWest());
                 return bnds;
             }, bounds);
-            that.set('_north', bounds.north);
-            that.set('_south', bounds.south);
-            that.set('_east', bounds.east);
-            that.set('_west', bounds.west);
+            that.set('north', bounds.north);
+            that.set('south', bounds.south);
+            that.set('east', bounds.east);
+            that.set('west', bounds.west);
             that.save_changes();
         });
     }


### PR DESCRIPTION
- Using readonly traits instead of properties for `south, west, east, north`, so that users can setup change handlers to them.
- Removal of the `default_tiles` trait, which is absorbed in the default handler for the layers trait.
- Allow for `add_layer` to take a basemap instead of a fully built tile layer. 

This should go into `0.7` since it is strictly a backward incompatible change.