### PR TITLE
Update CustomTMS examples use of default tiles.

### DIFF
--- a/examples/CustomTMS.ipynb
+++ b/examples/CustomTMS.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m = Map(default_tiles=TileLayer(opacity=1.0), center=center, zoom=zoom)\n",
+    "m = Map(center=center, zoom=zoom)\n",
     "m"
    ]
   },
@@ -59,39 +59,28 @@
     "carto_url = (\n",
     "    'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png'\n",
     ")\n",
-    "m.default_tiles.interact(url=carto_url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "m.remove_layer(m.default_tiles)\n",
-    "m.add_layer(m.default_tiles)"
+    "m.clear_layers()\n",
+    "m.add_layer(TileLayer(url=carto_url))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removes the use of Map.default_tiles which was removed in Release 0.7.0.